### PR TITLE
Feature/subnet mask and listen addresses

### DIFF
--- a/molecule/resources/inventory/host_vars/db/vars
+++ b/molecule/resources/inventory/host_vars/db/vars
@@ -10,7 +10,8 @@ postgresql_connection:
   host: "{{ db_vm.hostname }}"
   port: "{{ db_vm.port }}"
   client_ip: "{{ web_vm.ip }}"
-  client_certificate_filename: "/var/lib/pgsql/certs/root.crt"  # required if using SSL, where to copy the client certificate to on the server
+  client_certificate_filename: "/var/lib/pgsql/certs/root.crt" # required if using SSL, where to copy the client certificate to on the server
+  listen_addresses: "'*'"
 
 # mirsg.ssl_certificates - postgresql server
 postgresql_ssl_certificate:
@@ -23,4 +24,4 @@ postgresql_ssl_certificate:
   csr_common_name: "{{ db_vm.hostname }}"
   certificate_filename: "/var/lib/pgsql/certs/server.crt"
   provider: "selfsigned"
-  cache_filename: "{{ database_server_certificate_cache_filename }}"  # where to store the server certificate in cache
+  cache_filename: "{{ database_server_certificate_cache_filename }}" # where to store the server certificate in cache

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -79,7 +79,7 @@ local   all             all                                     peer
 
 # IPv4 local connections:
 {% if postgresql_use_ssl %}
-hostssl    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask|default(255.255.255.255) }}    md5    clientcert=1
+hostssl    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask|default('255.255.255.255') }}    md5    clientcert=1
 {% else %}
-host    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask|default(255.255.255.255) }}    md5
+host    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask|default('255.255.255.255') }}    md5
 {% endif %}

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -79,7 +79,7 @@ local   all             all                                     peer
 
 # IPv4 local connections:
 {% if postgresql_use_ssl %}
-hostssl    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    255.255.255.255    md5    clientcert=1
+hostssl    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask|default(255.255.255.255) }}    md5    clientcert=1
 {% else %}
-host    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    255.255.255.255    md5
+host    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask|default(255.255.255.255) }}    md5
 {% endif %}

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -56,8 +56,8 @@
 
 # - Connection Settings -
 
-#listen_addresses = 'localhost,{{ postgresql_connection.host }}'
-listen_addresses = '*'
+listen_addresses = {{ postgresql_connection.listen_addresses|default('localhost, postgresql_connection.host') }}
+#listen_addresses = '*'
                     # comma-separated list of addresses;
                     # defaults to 'localhost'; use '*' for all
                     # (change requires restart)


### PR DESCRIPTION
Changes:

- Added `subnet_mask` variable to `pg_hba.conf.j2` to allow flexibility in the number of IP addresses that can connect to the database.
- Added `listen_addresses` variable to `postgresql.conf.j2` to allow flexibility in the addresses on which Postgresql is listening. When set to `'*'` it will listen on all addresses; defaults to `'localhost, <host_ip>'`.

Closes #3 and #4 