### PR TITLE
Fix/symlink task 6

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,6 +104,7 @@
     src: "{{ postgresql_storage.data_directory }}"
     dest: "{{ postgresql.data_directory }}"
     state: link
+  when: postgresql_storage.data_directory != postgresql.data_directory
 
 - name: Create PostgreSQL database directory if it does not already exist
   ansible.builtin.command: "{{ postgresql.setup_command }} initdb"

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -56,7 +56,7 @@
 
 # - Connection Settings -
 
-listen_addresses = {{ postgresql_connection.listen_addresses|default('localhost, postgresql_connection.host') }}
+listen_addresses = {{ postgresql_connection.listen_addresses|default('localhost, ' + postgresql_connection.host) }}
 #listen_addresses = '*'
                     # comma-separated list of addresses;
                     # defaults to 'localhost'; use '*' for all


### PR DESCRIPTION
Changes:

- Only create symbolic link if `postgresql_storage.data_directory` is not the same directory as `postgresql.data_directory`.
- Fix default value for `listen_addresses`.