### PR TITLE
Set clientcert=verify-ca in pg_hba.conf when using SSL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,6 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v6.3.0
+    rev: v6.17.2
     hooks:
       - id: ansible-lint

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,6 @@
 
 - name: Restore selinux contexts
   ansible.builtin.command: restorecon -R -v {{ postgresql.base_directory }}
+  register: restore_selinux_contexts
+  changed_when:
+    - "'restorecon reset' in restore_selinux_contexts.stdout"

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -62,7 +62,7 @@
       ansible.builtin.include_role:
         name: "mirsg.ssl_certificates"
       vars:
-        ssl_certificate: "{{ postgresql_client_ssl_certificate }}"
+        ssl_certificate: "{{ postgresql_client_ssl_certificate }}" # noqa: var-naming[no-role-prefix]
 
 - name: Prepare - install and start crontabs on the db
   hosts: db

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -145,7 +145,7 @@
       ansible.builtin.include_role:
         name: mirsg.ssl_certificates
       vars:
-        ssl_certificate: "{{ postgresql_ssl_certificate }}"
+        ssl_certificate: "{{ postgresql_ssl_certificate }}" # noqa: var-naming[no-role-prefix]
 
     - name: Get postgresql client certificate from cache
       ansible.builtin.copy:

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -79,7 +79,7 @@ local   all             all                                     peer
 
 # IPv4 local connections:
 {% if postgresql_use_ssl %}
-hostssl    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask }}    md5    clientcert=1
+hostssl    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask }}    md5    clientcert=verify-ca
 {% else %}
 host    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask }}    md5
 {% endif %}


### PR DESCRIPTION
Fixes #11 

- Set `clientcert=verify-ca` in `pg_hba.conf` when using SSL as `clientcert=1` is deprecated

Also:
- update the ansible-lint pre-commit hook
- fix (or ignore) ansible-lint complaints