### PR TITLE
Extend postgresql service definition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,6 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v6.3.0
+    rev: v6.17.2
     hooks:
       - id: ansible-lint

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ postgresql:
 # mirsg.postgresql - service
 postgresql_service:
   name: "{{ postgresql_service_name }}"
-  filename: "/etc/systemd/system/{{ postgresql_service_name }}.service"
+  filename: "/etc/systemd/system/{{ postgresql_service_name }}.service.d/postgresql_service.conf"
 
 # mirsg.postgresql - storage
 postgresql_storage:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ postgresql:
 # mirsg.postgresql - service
 postgresql_service:
   name: "{{ postgresql_service_name }}"
+  directory: "/etc/systemd/system/{{ postgresql_service_name }}.service.d"
   filename: "/etc/systemd/system/{{ postgresql_service_name }}.service.d/postgresql_service.conf"
 
 # mirsg.postgresql - storage

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,6 @@
 
 - name: Restore selinux contexts
   ansible.builtin.command: restorecon -R -v {{ postgresql.base_directory }}
+  register: restore_selinux_contexts
+  changed_when:
+    - "'restorecon reset' in restore_selinux_contexts.stdout"

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -62,7 +62,7 @@
       ansible.builtin.include_role:
         name: "mirsg.ssl_certificates"
       vars:
-        ssl_certificate: "{{ postgresql_client_ssl_certificate }}"
+        ssl_certificate: "{{ postgresql_client_ssl_certificate }}" # noqa: var-naming[no-role-prefix]
 
 - name: Prepare - install and start crontabs on the db
   hosts: db

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,13 @@
     state: stopped
   changed_when: false
 
+- name: Ensure postgresql service configuration directory exists
+  ansible.builtin.file:
+    path: "{{ postgresql_service.directory }}"
+    owner: "root"
+    group: "root"
+    mode: 0755
+
 - name: Set custom postgresql service configuration
   ansible.builtin.template:
     src: postgresql.service.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,7 @@
     path: "{{ postgresql_service.directory }}"
     owner: "root"
     group: "root"
+    state: directory
     mode: 0755
 
 - name: Set custom postgresql service configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -145,7 +145,7 @@
       ansible.builtin.include_role:
         name: mirsg.ssl_certificates
       vars:
-        ssl_certificate: "{{ postgresql_ssl_certificate }}"
+        ssl_certificate: "{{ postgresql_ssl_certificate }}" # noqa: var-naming[no-role-prefix]
 
     - name: Get postgresql client certificate from cache
       ansible.builtin.copy:

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -79,7 +79,7 @@ local   all             all                                     peer
 
 # IPv4 local connections:
 {% if postgresql_use_ssl %}
-hostssl    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask }}    md5    clientcert=1
+hostssl    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask }}    md5    clientcert=verify-ca
 {% else %}
 host    {{ postgresql_database.database_name }}            {{ postgresql_database.user_name }}            {{ postgresql_connection.client_ip }}    {{ postgresql_connection.subnet_mask }}    md5
 {% endif %}

--- a/templates/postgresql.service.j2
+++ b/templates/postgresql.service.j2
@@ -1,5 +1,3 @@
-.include /lib/systemd/system/{{ postgresql_service_name }}.service
-
 [Service]
 Environment=PGPORT={{ postgresql_connection.port }}
 Environment=PGDATA={{ postgresql.data_directory }}


### PR DESCRIPTION
Fixes #10 

Requires #12 to be merged first (as that pr updates the ansible-lint pre-commit hook)

- define a variable `postgresql_service.directory` for extending the service configuration, defaults to:
```
"/etc/systemd/system/{{ postgresql_service_name }}.service.d"
```
- update the default `postgresql_service.filename`:
```
filename: "/etc/systemd/system/{{ postgresql_service_name }}.service.d/postgresql_service.conf"
```
- add a task to ensure `postgresql_service.directory` exists
- remove the `.include` command from the `pg_hba.conf.j2` template