### PR TITLE
Add a tagged task to restart postgres

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 # handlers file for postgresql
 - name: Restart postgresql
+  tags: restart
   ansible.builtin.service:
     name: "{{ postgresql_service.name }}"
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -145,6 +145,13 @@
     group: "{{ postgresql.group }}"
     mode: 0640
 
+- name: Noop to restart postgresql
+  tags: restart
+  ansible.builtin.debug:
+    msg: trigger postgresql restart
+  notify: Restart postgresql
+  changed_when: true
+
 - name: Setup SSL
   when: postgresql_use_ssl
   notify: Restart postgresql

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -150,7 +150,7 @@
   ansible.builtin.debug:
     msg: trigger postgresql restart
   notify: Restart postgresql
-  changed_when: true
+  changed_when: false
 
 - name: Setup SSL
   when: postgresql_use_ssl


### PR DESCRIPTION
Changes made:

- added a task to restart postgres, tagged with `restart`
- can run only tasks tagged `restart`:
```bash
ansible-playbook -i hosts myplaybook.yml --tags "restart"
```